### PR TITLE
Resolving the long key issue in the serialized file

### DIFF
--- a/foreshadow/steps/feature_engineerer.py
+++ b/foreshadow/steps/feature_engineerer.py
@@ -47,21 +47,23 @@ class FeatureEngineererMapper(PreparerStep, AutoIntentMixin):
             columns_by_intent = group_by(columns_by_domain[domain], "intent")
             for intent in columns_by_intent:
                 columns_by_domain_and_intent[
-                    str(domain) + "_" + intent
+                    str(domain) + "_" + str(intent)
                 ] += columns_by_intent[intent]
         """Instead of using i as the outer layer key,
         should we use some more specific like the key
         in columns_by_domain_and_intent, which is ${domain}_${intent}?
         """
-
-        columns_by_domain_and_intent = list(
-            columns_by_domain_and_intent.values()
-        )
+        column_groups = []
+        group_criterion = []
+        for key, val in columns_by_domain_and_intent.items():
+            group_criterion.append(key)
+            column_groups.append(val)
 
         return self.separate_cols(
             transformers=[
                 [_FeatureEngineerer(column_sharer=self.column_sharer)]
-                for col_group in columns_by_domain_and_intent
+                for col_group in column_groups
             ],
-            cols=columns_by_domain_and_intent,
+            cols=column_groups,
+            criterion=group_criterion,
         )

--- a/foreshadow/steps/feature_reducer.py
+++ b/foreshadow/steps/feature_reducer.py
@@ -95,7 +95,13 @@ class FeatureReducerMapper(PreparerStep, AutoIntentMixin):
             return result
 
         columns = X.columns.values.tolist()
-        columns_by_intent = list(group_by(columns, "intent").values())
+        columns_by_intent = group_by(columns, "intent")
+
+        column_groups = []
+        group_criterion = []
+        for key, val in columns_by_intent.items():
+            group_criterion.append(key)
+            column_groups.append(val)
 
         """Not sure where the drop_feature functionality would apply.
         Would reducer produce empty columns? If yes, the concrete reducer
@@ -105,7 +111,8 @@ class FeatureReducerMapper(PreparerStep, AutoIntentMixin):
         return self.separate_cols(
             transformers=[
                 [_FeatureReducer(column_sharer=self.column_sharer)]
-                for col_group in columns_by_intent
+                for col_group in column_groups
             ],
-            cols=columns_by_intent,
+            cols=column_groups,
+            criterion=group_criterion,
         )

--- a/foreshadow/steps/preprocessor.py
+++ b/foreshadow/steps/preprocessor.py
@@ -36,7 +36,7 @@ class Preprocessor(PreparerStep, AutoIntentMixin):
                 ]
             else:
                 transformer_list = None  # None or []
-            pm.add([c], transformer_list)
+            pm.add([c], transformer_list, i)
         return pm
 
     def get_mapping(self, X):

--- a/foreshadow/tests/test_preparer.py
+++ b/foreshadow/tests/test_preparer.py
@@ -119,8 +119,8 @@ def test_data_preparer_deserialization():
 
     boston_path = get_file_path("data", "boston_housing.csv")
     data = pd.read_csv(boston_path)
-    # data = data[["crim", "indus", "ptratio", "tax", "zn"]]
-    # data = data[["nox"]]
+    data = data[["crim", "indus", "ptratio", "tax", "zn"]]
+    # data = data[["tax", "zn"]]
 
     cs = ColumnSharer()
     dp = DataPreparer(cs)

--- a/foreshadow/tests/test_transformers/test_concrete/test_feature_engineerers/test_feature_engineer.py
+++ b/foreshadow/tests/test_transformers/test_concrete/test_feature_engineerers/test_feature_engineer.py
@@ -62,8 +62,16 @@ def test_feature_engineerer_get_mapping():
     column_mapping = fem.get_mapping(data)
 
     check_pm = PreparerMapping()
-    check_pm.add(["age", "weights"], [FeatureEngineerer(column_sharer=cs)])
-    check_pm.add(["financials"], [FeatureEngineerer(column_sharer=cs)])
+    check_pm.add(
+        ["age", "weights"],
+        [FeatureEngineerer(column_sharer=cs)],
+        "personal_Numeric",
+    )
+    check_pm.add(
+        ["financials"],
+        [FeatureEngineerer(column_sharer=cs)],
+        "financial_Numeric",
+    )
 
     for key in column_mapping.store:
         assert key in check_pm.store

--- a/foreshadow/tests/test_transformers/test_concrete/test_feature_reducer/test_feature_reducer.py
+++ b/foreshadow/tests/test_transformers/test_concrete/test_feature_reducer/test_feature_reducer.py
@@ -55,9 +55,6 @@ def test_feature_reducer_get_mapping_by_intent():
 
     fr = FeatureReducerMapper(column_sharer=cs)
     column_mapping = fr.get_mapping(data)
-    import pdb
-
-    pdb.set_trace()
 
     check = PreparerMapping()
     check.add(

--- a/foreshadow/tests/test_transformers/test_concrete/test_feature_reducer/test_feature_reducer.py
+++ b/foreshadow/tests/test_transformers/test_concrete/test_feature_reducer/test_feature_reducer.py
@@ -55,10 +55,17 @@ def test_feature_reducer_get_mapping_by_intent():
 
     fr = FeatureReducerMapper(column_sharer=cs)
     column_mapping = fr.get_mapping(data)
+    import pdb
+
+    pdb.set_trace()
 
     check = PreparerMapping()
-    check.add(["age", "weights"], [FeatureReducer(column_sharer=cs)])
-    check.add(["occupation"], [FeatureReducer(column_sharer=cs)])
+    check.add(
+        ["age", "weights"], [FeatureReducer(column_sharer=cs)], "Numeric"
+    )
+    check.add(
+        ["occupation"], [FeatureReducer(column_sharer=cs)], "Categorical"
+    )
 
     for key in column_mapping.store:
         assert key in check.store


### PR DESCRIPTION

### Description
This change handles the long key issue in the serialized file. Currently, when we group columns, we may end up with a block of JSON like:
```
"col1,col2,col3,...,col40": {...}
```
It could be very verbose when we have a lot of columns in a group.

The new implementation changes the output to:
```
"group_criteria": {
    "pipeline": {...},
    "columns": ["col1", "col2", "col3", ...,]
}
```
or
```
"single_column": {
    "pipeline": {...}
}
```
The motivation behind this is that:
- If we want to display what columns are in a group, there is no way around it but to include them in a file. We have to show all the columns somewhere, if we want to deserialize them back or want the users to play with override (moving some columns to another group).
- Treating it as a list in JSON allows the user to shrink them by any modern editor that can parse JSON.
- Scrolling up and down seems more natural comparing to left and right when viewing a JSON output file in an editor.

