### PR TITLE
Turnoff deep serialization

### DIFF
--- a/foreshadow/columnsharer.py
+++ b/foreshadow/columnsharer.py
@@ -44,7 +44,7 @@ class ColumnSharer(MutableMapping, ConcreteSerializerMixin):
             lambda: False, acceptable_keys
         )
 
-    def dict_serialize(self, deep=True):
+    def dict_serialize(self, deep=False):
         """Serialize the init parameters (dictionary form) of a columnsharer.
 
         Args:

--- a/foreshadow/estimators/auto.py
+++ b/foreshadow/estimators/auto.py
@@ -41,8 +41,8 @@ class AutoEstimator(BaseEstimator, ConcreteSerializerMixin):
         self.estimator_class = None
         self.estimator = None
 
-    def dict_serialize(self, deep=True):  # noqa
-        return super().dict_serialize(deep=False)
+    # def dict_serialize(self, deep=False):  # noqa
+    #     return super().dict_serialize(deep=False)
 
     @property
     def problem_type(self):

--- a/foreshadow/estimators/auto.py
+++ b/foreshadow/estimators/auto.py
@@ -41,9 +41,6 @@ class AutoEstimator(BaseEstimator, ConcreteSerializerMixin):
         self.estimator_class = None
         self.estimator = None
 
-    # def dict_serialize(self, deep=False):  # noqa
-    #     return super().dict_serialize(deep=False)
-
     @property
     def problem_type(self):
         """Type of machine learning problem.

--- a/foreshadow/preparer.py
+++ b/foreshadow/preparer.py
@@ -125,7 +125,7 @@ class DataPreparer(
         # adding steps to the get_params()
         return out
 
-    def dict_serialize(self, deep=True):
+    def dict_serialize(self, deep=False):
         """Serialize the data preparer.
 
         Args:

--- a/foreshadow/smart/smart.py
+++ b/foreshadow/smart/smart.py
@@ -77,10 +77,6 @@ class SmartTransformer(
         self.transformer = transformer
         self.check_wrapped = check_wrapped
 
-    def dict_serialize(self, deep=True):  # noqa
-        serialized = super().dict_serialize(deep=False)
-        return serialized
-
     @property
     def transformer(self):
         """Get the selected transformer from the SmartTransformer.

--- a/foreshadow/steps/preparerstep.py
+++ b/foreshadow/steps/preparerstep.py
@@ -291,7 +291,7 @@ class PreparerStep(
         super().configure_column_sharer(column_sharer)
         self._parallel_process.configure_column_sharer(column_sharer)
 
-    def dict_serialize(self, deep=True):
+    def dict_serialize(self, deep=False):
         """Serialize the preparestep.
 
         It renames transformer_list to transformation_by_column_group.


### PR DESCRIPTION
### Description
Based on how we use dict_serialization, there is no point of using deep=True in most cases. By setting the argument default value to False, we could make the code base cleaner. 