### PR TITLE
remove deep=True in the test as it is not needed and cause verbose ou…

### DIFF
--- a/foreshadow/tests/test_preparer.py
+++ b/foreshadow/tests/test_preparer.py
@@ -126,9 +126,9 @@ def test_data_preparer_deserialization():
     dp = DataPreparer(cs)
     dp.fit(data)
     data_transformed = dp.transform(data)
-    dp.to_json("data_preparerer_deep_true.json", deep=True)
+    dp.to_json("data_preparerer.json")
 
-    dp2 = DataPreparer.from_json("data_preparerer_deep_true.json")
+    dp2 = DataPreparer.from_json("data_preparerer.json")
     dp2.fit(data)
     data_transformed2 = dp2.transform(data)
 


### PR DESCRIPTION
### Description
Fix a unit test by turning off deep=True. It is not required and causes verbose output. 