### PR TITLE
Handle y variable transformation based on problem type.

### DIFF
--- a/foreshadow/console.py
+++ b/foreshadow/console.py
@@ -6,14 +6,13 @@ import sys
 import warnings
 
 import pandas as pd
-from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
 
 from foreshadow.config import config
 from foreshadow.estimators import AutoEstimator
 from foreshadow.foreshadow import Foreshadow
-from foreshadow.utils import EstimatorFactory, EstimatorFamily, ProblemType
 from foreshadow.logging import logging
+from foreshadow.utils import EstimatorFactory, EstimatorFamily, ProblemType
 
 
 def process_argument(args):  # noqa: C901
@@ -153,9 +152,10 @@ def generate_model(args):  # noqa: C901
     if cargs.level == 1:
         # Default everything with basic estimator
         fs = Foreshadow(
+            problem_type=cargs.problem_type,
             estimator=get_method(
                 cargs.method, y_train, cargs.family, cargs.problem_type
-            )
+            ),
         )
 
     # elif cargs.level == 2:
@@ -218,12 +218,14 @@ def generate_model(args):  # noqa: C901
             **estimator.estimator_kwargs,
         }
 
-        fs = Foreshadow(estimator=estimator)
+        fs = Foreshadow(problem_type=cargs.problem_type, estimator=estimator)
 
     else:
         raise ValueError("Invalid Level. Only levels 1 and 3 supported.")
 
     if cargs.multiprocess:
+        # TODO reconsider this implementation as it will not work if
+        #  foreshadow is used as a library/API.
         config.set_multiprocess(True)
         logging.info("multiprocessing enabled.")
 

--- a/foreshadow/foreshadow.py
+++ b/foreshadow/foreshadow.py
@@ -16,14 +16,14 @@ from foreshadow.serializers import (
     ConcreteSerializerMixin,
     _make_deserializable,
 )
-from foreshadow.utils import check_df, get_transformer
+from foreshadow.utils import ProblemType, check_df, get_transformer
 
 
 class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
     """An end-to-end pipeline to preprocess and tune a machine learning model.
 
     Example:
-        >>> shadow = Foreshadow()
+        >>> shadow = Foreshadow(problem_type=ProblemType.CLASSIFICATION)
 
     Args:
         X_preparer \
@@ -47,9 +47,23 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
         X_preparer=None,
         y_preparer=None,
         estimator=None,
+        problem_type=None,
         optimizer=None,
         optimizer_kwargs=None,
     ):
+        if problem_type not in [
+            ProblemType.CLASSIFICATION,
+            ProblemType.REGRESSION,
+        ]:
+            raise ValueError(
+                "Unknown Problem Type {}. Please choose from {} "
+                "or {}".format(
+                    problem_type,
+                    ProblemType.CLASSIFICATION,
+                    ProblemType.REGRESSION,
+                )
+            )
+        self.problem_type = problem_type
         self.X_preparer = X_preparer
         self.y_preparer = y_preparer
         self.estimator = estimator
@@ -131,7 +145,9 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
                 raise ValueError("Invalid value passed as y_preparer")
         else:
             self._y_preprocessor = DataPreparer(
-                column_sharer=ColumnSharer(), y_var=True
+                column_sharer=ColumnSharer(),
+                y_var=True,
+                problem_type=self.problem_type,
             )
 
     @property

--- a/foreshadow/preparer.py
+++ b/foreshadow/preparer.py
@@ -7,6 +7,7 @@ from foreshadow.serializers import (
     _make_deserializable,
     _make_serializable,
 )
+from foreshadow.smart import CategoricalEncoder
 from foreshadow.steps import (
     CleanerMapper,
     FeatureEngineererMapper,
@@ -15,7 +16,7 @@ from foreshadow.steps import (
     IntentMapper,
     Preprocessor,
 )
-from foreshadow.utils import ConfigureColumnSharerMixin
+from foreshadow.utils import ConfigureColumnSharerMixin, ProblemType
 
 from .concrete import NoTransform
 
@@ -80,6 +81,7 @@ class DataPreparer(
         engineerer_kwargs=None,
         preprocessor_kwargs=None,
         reducer_kwargs=None,
+        problem_type=None,
         y_var=None,
         **kwargs
     ):
@@ -117,13 +119,21 @@ class DataPreparer(
                 ("feature_reducer", FeatureReducerMapper(**reducer_kwargs_)),
             ]
         else:
-            steps = [("output", NoTransform())]
+            if problem_type == ProblemType.REGRESSION:
+                steps = [("output", NoTransform())]
+            elif problem_type == ProblemType.CLASSIFICATION:
+                steps = [("output", CategoricalEncoder(y_var=True))]
+            else:
+                raise ValueError(
+                    "Invalid Problem " "Type {}".format(problem_type)
+                )
         if "steps" in kwargs:  # needed for sklearn estimator clone,
             # which will try to init the object using get_params.
             steps = kwargs.pop("steps")
 
         self.column_sharer = column_sharer
         self.y_var = y_var
+        self.problem_type = problem_type
         super().__init__(steps, **kwargs)
 
     def _get_params(self, attr, deep=True):

--- a/foreshadow/tests/test_console.py
+++ b/foreshadow/tests/test_console.py
@@ -208,7 +208,9 @@ def test_console_execute():
     X_train, X_test, y_train, y_test = train_test_split(
         X_df, y_df, test_size=0.2
     )
-    fs = Foreshadow(estimator=LinearRegression())
+    fs = Foreshadow(
+        problem_type=ProblemType.REGRESSION, estimator=LinearRegression()
+    )
 
     results = execute_model(fs, X_train, y_train, X_test, y_test)
 
@@ -369,6 +371,7 @@ def test_console_generate_and_execute_model(
     assert isinstance(model[0].estimator.estimator, estimator)
 
     execute_model(*model)
+
 
 def test_console_parse_args_multiprocess():
     from foreshadow.console import process_argument

--- a/foreshadow/tests/test_foreshadow.py
+++ b/foreshadow/tests/test_foreshadow.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from foreshadow.utils import ProblemType
 from foreshadow.utils.testing import get_file_path
 
 
@@ -22,7 +23,7 @@ def test_foreshadow_defaults():
     from foreshadow.estimators import AutoEstimator
     from foreshadow.estimators import MetaEstimator
 
-    foreshadow = Foreshadow()
+    foreshadow = Foreshadow(problem_type=ProblemType.CLASSIFICATION)
     # defaults
     assert (
         isinstance(foreshadow.X_preparer, DataPreparer)
@@ -38,18 +39,21 @@ def test_foreshadow_defaults():
 def test_foreshadow_X_preparer_false():
     from foreshadow.foreshadow import Foreshadow
 
-    foreshadow = Foreshadow(X_preparer=False)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION, X_preparer=False
+    )
     assert foreshadow.X_preparer is None
 
 
-# @pytest.mark.skip("THIS IS IMPORTANT FIX")
 def test_foreshadow_X_preparer_custom():
     from foreshadow.foreshadow import Foreshadow
     from foreshadow.preparer import DataPreparer
     from foreshadow.columnsharer import ColumnSharer
 
     dp = DataPreparer(column_sharer=ColumnSharer())
-    foreshadow = Foreshadow(X_preparer=dp)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION, X_preparer=dp
+    )
     assert foreshadow.X_preparer == dp
 
 
@@ -58,7 +62,9 @@ def test_foreshadow_X_preparer_error():
 
     preprocessor = "Invalid"
     with pytest.raises(ValueError) as e:
-        _ = Foreshadow(X_preparer=preprocessor)
+        _ = Foreshadow(
+            problem_type=ProblemType.CLASSIFICATION, X_preparer=preprocessor
+        )
 
     assert str(e.value) == "Invalid value: 'Invalid' passed as X_preparer"
 
@@ -66,7 +72,9 @@ def test_foreshadow_X_preparer_error():
 def test_foreshadow_y_preparer_false():
     from foreshadow.foreshadow import Foreshadow
 
-    foreshadow = Foreshadow(y_preparer=False)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION, y_preparer=False
+    )
     assert foreshadow.y_preparer is None
 
 
@@ -75,7 +83,9 @@ def test_foreshadow_y_preparer_custom():
     from foreshadow.preparer import DataPreparer
 
     dp = DataPreparer()
-    foreshadow = Foreshadow(y_preparer=dp)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION, y_preparer=dp
+    )
     assert type(foreshadow.y_preparer) == DataPreparer
 
 
@@ -84,7 +94,7 @@ def test_foreshadow_y_preparer_error():
 
     dp = "Invalid"
     with pytest.raises(ValueError) as e:
-        _ = Foreshadow(y_preparer=dp)
+        _ = Foreshadow(problem_type=ProblemType.CLASSIFICATION, y_preparer=dp)
 
     assert str(e.value) == "Invalid value passed as y_preparer"
 
@@ -94,7 +104,9 @@ def test_foreshadow_estimator_custom():
     from foreshadow.base import BaseEstimator
 
     estimator = BaseEstimator()
-    foreshadow = Foreshadow(estimator=estimator)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION, estimator=estimator
+    )
     assert isinstance(foreshadow.estimator, BaseEstimator)
 
 
@@ -103,7 +115,9 @@ def test_foreshadow_estimator_error():
 
     estimator = "Invalid"
     with pytest.raises(ValueError) as e:
-        _ = Foreshadow(estimator=estimator)
+        _ = Foreshadow(
+            problem_type=ProblemType.CLASSIFICATION, estimator=estimator
+        )
 
     assert str(e.value) == "Invalid value passed as estimator"
 
@@ -118,7 +132,11 @@ def test_foreshadow_optimizer_custom():
 
     # Need custom estimator to avoid warning
     estimator = BaseEstimator()
-    foreshadow = Foreshadow(estimator=estimator, optimizer=DummySearch)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION,
+        estimator=estimator,
+        optimizer=DummySearch,
+    )
     assert issubclass(foreshadow.optimizer, BaseSearchCV)
 
 
@@ -127,7 +145,9 @@ def test_foreshadow_optimizer_error_invalid():
 
     optimizer = "Invalid"
     with pytest.raises(ValueError) as e:
-        _ = Foreshadow(optimizer=optimizer)
+        _ = Foreshadow(
+            problem_type=ProblemType.CLASSIFICATION, optimizer=optimizer
+        )
 
     assert str(e.value) == "Invalid optimizer: 'Invalid' passed."
 
@@ -137,7 +157,9 @@ def test_foreshadow_optimizer_error_wrongclass():
 
     optimizer = Foreshadow
     with pytest.raises(ValueError) as e:
-        _ = Foreshadow(optimizer=optimizer)
+        _ = Foreshadow(
+            problem_type=ProblemType.CLASSIFICATION, optimizer=optimizer
+        )
 
     assert (
         str(e.value) == "Invalid optimizer: '<class "
@@ -153,7 +175,9 @@ def test_foreshadow_warns_on_set_estimator_optimizer():
         pass
 
     with pytest.warns(Warning) as w:
-        _ = Foreshadow(optimizer=DummySearch)
+        _ = Foreshadow(
+            problem_type=ProblemType.CLASSIFICATION, optimizer=DummySearch
+        )
 
     assert str(w[0].message) == (
         "An automatic estimator cannot be used with an"
@@ -182,7 +206,11 @@ def test_foreshadow_custom_fit_estimate(mocker):
     # Let foreshadow set to defaults, we will overwrite them
     X_preparer = mocker.PropertyMock(return_value=X_pipeline)
     mocker.patch.object(Foreshadow, "X_preparer", X_preparer)
-    foreshadow = Foreshadow(y_preparer=False, estimator=estimator)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION,
+        y_preparer=False,
+        estimator=estimator,
+    )
 
     foreshadow.fit(X_train, y_train)
     foreshadow_predict = foreshadow.predict(X_test)
@@ -231,7 +259,11 @@ def test_foreshadow_y_preparer(mocker):
     # Let foreshadow set to defaults, we will overwrite them
     y_preparer = mocker.PropertyMock(return_value=y_pipeline)
     mocker.patch.object(Foreshadow, "y_preparer", y_preparer)
-    foreshadow = Foreshadow(y_preparer=False, estimator=estimator)
+    foreshadow = Foreshadow(
+        problem_type=ProblemType.REGRESSION,
+        y_preparer=False,
+        estimator=estimator,
+    )
     foreshadow.fit(X_train, y_train)
     foreshadow_predict = foreshadow.predict(X_test)
     foreshadow_score = foreshadow.score(X_test, y_test)
@@ -268,7 +300,10 @@ def test_foreshadow_without_x_processor():
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
     foreshadow = Foreshadow(
-        X_preparer=False, y_preparer=False, estimator=estimator
+        problem_type=ProblemType.REGRESSION,
+        X_preparer=False,
+        y_preparer=False,
+        estimator=estimator,
     )
     foreshadow.fit(X_train, y_train)
     foreshadow_predict = foreshadow.predict(X_test)
@@ -313,7 +348,10 @@ def test_foreshadow_predict_before_fit():
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
     foreshadow = Foreshadow(
-        X_preparer=False, y_preparer=False, estimator=estimator
+        problem_type=ProblemType.REGRESSION,
+        X_preparer=False,
+        y_preparer=False,
+        estimator=estimator,
     )
 
     with pytest.raises(ValueError) as e:
@@ -335,7 +373,10 @@ def test_foreshadow_predict_diff_cols():
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1)
 
     foreshadow = Foreshadow(
-        X_preparer=False, y_preparer=False, estimator=estimator
+        problem_type=ProblemType.REGRESSION,
+        X_preparer=False,
+        y_preparer=False,
+        estimator=estimator,
     )
     foreshadow.fit(X_train, y_train)
 
@@ -377,7 +418,11 @@ def test_foreshadow_param_optimize_fit(mocker):
         "foreshadow.preparer.DataPreparer", return_value=DummyDataPreparer
     )
 
-    fs = Foreshadow(estimator=DummyRegressor(), optimizer=DummySearch)
+    fs = Foreshadow(
+        problem_type=ProblemType.REGRESSION,
+        estimator=DummyRegressor(),
+        optimizer=DummySearch,
+    )
     x = data.drop(["medv"], axis=1, inplace=False)
     y = data[["medv"]]
 
@@ -385,6 +430,7 @@ def test_foreshadow_param_optimize_fit(mocker):
     assert isinstance(fs.pipeline.steps[-1][1].estimator, DummyRegressor)
 
     fs2 = Foreshadow(
+        problem_type=ProblemType.REGRESSION,
         X_preparer=False,
         y_preparer=False,
         estimator=DummyRegressor(),
@@ -419,7 +465,11 @@ def test_foreshadow_param_optimize():  # TODO: Make this test faster
     js = json.load(open(test_json_path, "r"))
 
     fs = Foreshadow(
-        DataPreparer(from_json=js), False, LinearRegression(), GridSearchCV
+        DataPreparer(from_json=js),
+        False,
+        LinearRegression(),
+        ProblemType.REGRESSION,
+        GridSearchCV,
     )
 
     fs.pipeline = Pipeline(
@@ -460,7 +510,13 @@ def test_foreshadow_param_optimize_no_config():
 
     data = pd.read_csv(boston_path)
 
-    fs = Foreshadow(DataPreparer(), False, LinearRegression(), GridSearchCV)
+    fs = Foreshadow(
+        DataPreparer(),
+        False,
+        LinearRegression(),
+        ProblemType.REGRESSION,
+        GridSearchCV,
+    )
 
     fs.pipeline = Pipeline(
         [("preparer", fs.X_preparer), ("estimator", fs.estimator)]
@@ -501,6 +557,7 @@ def test_foreshadow_param_optimize_no_combinations():
         DataPreparer(column_sharer=ColumnSharer(), from_json={}),
         False,
         LinearRegression(),
+        ProblemType.REGRESSION,
         GridSearchCV,
     )
 
@@ -545,6 +602,7 @@ def test_foreshadow_param_optimize_invalid_array_idx():
         DataPreparer(ColumnSharer(), from_json=cfg),
         False,
         LinearRegression(),
+        ProblemType.REGRESSION,
         GridSearchCV,
     )
 
@@ -586,6 +644,7 @@ def test_foreshadow_param_optimize_invalid_dict_key():
         ),
         False,
         LinearRegression(),
+        ProblemType.REGRESSION,
         GridSearchCV,
     )
 
@@ -620,7 +679,9 @@ def test_core_foreshadow_example_regression():
     X_train, X_test, y_train, y_test = train_test_split(
         bostonX_df, bostony_df, test_size=0.2
     )
-    model = Foreshadow(estimator=LinearRegression())
+    model = Foreshadow(
+        estimator=LinearRegression(), problem_type=ProblemType.REGRESSION
+    )
     model.fit(X_train, y_train)
     score = r2_score(y_test, model.predict(X_test))
     print("Boston score: %f" % score)
@@ -643,10 +704,22 @@ def test_core_foreshadow_example_classification():
         irisX_df, irisy_df, test_size=0.2
     )
 
-    model = Foreshadow(estimator=LogisticRegression())
+    model = Foreshadow(
+        estimator=LogisticRegression(), problem_type=ProblemType.CLASSIFICATION
+    )
     model.fit(X_train, y_train)
     score = f1_score(y_test, model.predict(X_test), average="weighted")
     print("Iris score: %f" % score)
+
+
+@pytest.mark.parametrize("problem_type", [None, "Unknown"])
+def test_foreshadow_unknown_problem_type(problem_type):
+    from foreshadow.foreshadow import Foreshadow
+
+    with pytest.raises(ValueError) as e:
+        _ = Foreshadow(problem_type=problem_type)
+
+    assert "Unknown Problem Type" in str(e.value)
 
 
 @pytest.mark.parametrize("deep", [True, False])
@@ -659,10 +732,11 @@ def test_foreshadow_get_params_keys(deep):
     """
     from foreshadow.foreshadow import Foreshadow
 
-    fs = Foreshadow()
+    fs = Foreshadow(problem_type=ProblemType.CLASSIFICATION)
     params = fs.get_params(deep=deep)
 
     desired_keys = [
+        "problem_type",
         "X_preparer",
         "estimator",
         "y_preparer",
@@ -691,7 +765,9 @@ def test_foreshadow_serialization_breast_cancer_non_auto_estimator():
         cancerX_df, cancery_df, test_size=0.2
     )
 
-    shadow = Foreshadow(estimator=LogisticRegression())
+    shadow = Foreshadow(
+        estimator=LogisticRegression(), problem_type=ProblemType.CLASSIFICATION
+    )
 
     shadow.fit(X_train, y_train)
 
@@ -711,12 +787,12 @@ def test_foreshadow_serialization_breast_cancer_non_auto_estimator():
     assertions.assertAlmostEqual(score1, score2, places=7)
 
 
+@slow
 def test_foreshadow_serialization_adults_small_classification():
     from foreshadow.foreshadow import Foreshadow
     import pandas as pd
     import numpy as np
     from sklearn.model_selection import train_test_split
-    from sklearn.linear_model import LogisticRegression
 
     np.random.seed(1337)
 
@@ -728,13 +804,23 @@ def test_foreshadow_serialization_adults_small_classification():
         X_df, y_df, test_size=0.2
     )
 
-    shadow = Foreshadow(estimator=LogisticRegression())
-    shadow.fit(X_train, y_train)
-    shadow.to_json("foreshadow_adults_small_logistic_regression.json")
+    from foreshadow.estimators import AutoEstimator
 
-    shadow2 = Foreshadow.from_json(
-        "foreshadow_adults_small_logistic_regression.json"
+    estimator = AutoEstimator(
+        problem_type=ProblemType.CLASSIFICATION, auto="tpot"
     )
+    estimator.configure_estimator(y_train)
+
+    estimator_kwargs = {"max_time_mins": 1, **estimator.estimator_kwargs}
+    estimator.estimator_kwargs = estimator_kwargs
+
+    shadow = Foreshadow(
+        estimator=estimator, problem_type=ProblemType.CLASSIFICATION
+    )
+    shadow.fit(X_train, y_train)
+    shadow.to_json("foreshadow_adults_small_tpot.json")
+
+    shadow2 = Foreshadow.from_json("foreshadow_adults_small_tpot.json")
     shadow2.fit(X_train, y_train)
 
     score1 = shadow.score(X_test, y_test)
@@ -743,7 +829,12 @@ def test_foreshadow_serialization_adults_small_classification():
     import unittest
 
     assertions = unittest.TestCase("__init__")
-    assertions.assertAlmostEqual(score1, score2, places=7)
+    # given the randomness of the tpot algorithm and the short run
+    # time we configured, there is no guarantee the performance can
+    # converge. The test here aims to evaluate if both cases have
+    # produced a reasonable score and the difference is small.
+    # assert score1 > 0.76 and score2 > 0.76
+    assertions.assertAlmostEqual(score1, score2, places=3)
 
 
 @slow
@@ -764,7 +855,9 @@ def test_foreshadow_serialization_adults_classification():
         X_df, y_df, test_size=0.2
     )
 
-    shadow = Foreshadow(estimator=LogisticRegression())
+    shadow = Foreshadow(
+        estimator=LogisticRegression(), problem_type=ProblemType.CLASSIFICATION
+    )
 
     shadow.fit(X_train, y_train)
     shadow.to_json("foreshadow_adults_logistic_regression.json")
@@ -803,7 +896,9 @@ def test_foreshadow_serialization_boston_housing_regression():
         X_df, y_df, test_size=0.2
     )
 
-    shadow = Foreshadow(estimator=LinearRegression())
+    shadow = Foreshadow(
+        estimator=LinearRegression(), problem_type=ProblemType.REGRESSION
+    )
 
     shadow.fit(X_train, y_train)
     shadow.to_json("foreshadow_boston_housing_linear_regression.json")
@@ -842,13 +937,17 @@ def test_foreshadow_serialization_tpot():
 
     from foreshadow.estimators import AutoEstimator
 
-    estimator = AutoEstimator(problem_type="classification", auto="tpot")
+    estimator = AutoEstimator(
+        problem_type=ProblemType.CLASSIFICATION, auto="tpot"
+    )
     estimator.configure_estimator(y_train)
 
     estimator_kwargs = {"max_time_mins": 1, **estimator.estimator_kwargs}
     estimator.estimator_kwargs = estimator_kwargs
 
-    shadow = Foreshadow(estimator=estimator)
+    shadow = Foreshadow(
+        estimator=estimator, problem_type=ProblemType.CLASSIFICATION
+    )
 
     shadow.fit(X_train, y_train)
 

--- a/foreshadow/tests/test_integration.py
+++ b/foreshadow/tests/test_integration.py
@@ -26,6 +26,7 @@ def test_integration_binary_classification():
     from sklearn.datasets import load_breast_cancer
     from sklearn.model_selection import train_test_split
     from sklearn.linear_model import LogisticRegression
+    from foreshadow.utils import ProblemType
 
     np.random.seed(1337)
 
@@ -36,7 +37,9 @@ def test_integration_binary_classification():
     X_train, X_test, y_train, y_test = train_test_split(
         cancerX_df, cancery_df, test_size=0.2
     )
-    shadow = fs.Foreshadow(estimator=LogisticRegression())
+    shadow = fs.Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION, estimator=LogisticRegression()
+    )
     shadow.fit(X_train, y_train)
 
     baseline = 0.9824561403508771
@@ -53,6 +56,7 @@ def test_integration_multiclass_classification():
     from sklearn.datasets import load_iris
     from sklearn.model_selection import train_test_split
     from sklearn.linear_model import LogisticRegression
+    from foreshadow.utils import ProblemType
 
     np.random.seed(1337)
 
@@ -63,7 +67,9 @@ def test_integration_multiclass_classification():
     X_train, X_test, y_train, y_test = train_test_split(
         irisX_df, irisy_df, test_size=0.2
     )
-    shadow = fs.Foreshadow(estimator=LogisticRegression())
+    shadow = fs.Foreshadow(
+        problem_type=ProblemType.CLASSIFICATION, estimator=LogisticRegression()
+    )
     shadow.fit(X_train, y_train)
 
     baseline = 0.9666666666666667
@@ -79,6 +85,7 @@ def test_integration_regression():
     from sklearn.datasets import load_boston
     from sklearn.model_selection import train_test_split
     from sklearn.linear_model import LinearRegression
+    from foreshadow.utils import ProblemType
 
     boston = load_boston()
     bostonX_df = pd.DataFrame(boston.data, columns=boston.feature_names)
@@ -87,7 +94,9 @@ def test_integration_regression():
     X_train, X_test, y_train, y_test = train_test_split(
         bostonX_df, bostony_df, test_size=0.2
     )
-    shadow = fs.Foreshadow(estimator=LinearRegression())
+    shadow = fs.Foreshadow(
+        problem_type=ProblemType.REGRESSION, estimator=LinearRegression()
+    )
     shadow.fit(X_train, y_train)
 
     baseline = 0.6953024611269096

--- a/foreshadow/tests/test_preparer.py
+++ b/foreshadow/tests/test_preparer.py
@@ -35,6 +35,15 @@ def test_data_preparer_init(cleaner_kwargs, expected_error):
         DataPreparer(cs, cleaner_kwargs=cleaner_kwargs)
 
 
+@pytest.mark.parametrize("problem_type", [None, "Unknown"])
+def test_data_preparer_y_variable(problem_type):
+    from foreshadow.preparer import DataPreparer
+
+    with pytest.raises(ValueError) as e:
+        DataPreparer(y_var=True, problem_type=problem_type)
+    assert "Invalid Problem Type" in str(e.value)
+
+
 @pytest.mark.parametrize("cleaner_kwargs", [({}), (None)])
 def test_data_preparer_fit(cleaner_kwargs):
     """Test fitting of DataPreparer after creation with kwargs.


### PR DESCRIPTION
# Description
Currently Foreshadow could not handle classification problems whose target variable is categorical, for example, categories like ">=50k" and "<50k". This change enables the labelencoding on y variables if we are dealing with classification but do nothing if it is a regression problem. 

The interface has changed since we have to specify the problem type when initializing the foreshadow object.

The unit test on running classification on the adult_small dataset with tpot showcases such capability.