### PR TITLE
Turn off BoxCox transformer because it may lead to potential bugs

### DIFF
--- a/foreshadow/smart/all.py
+++ b/foreshadow/smart/all.py
@@ -21,7 +21,6 @@ from foreshadow.concrete.externals import (
     TfidfVectorizer,
 )
 from foreshadow.concrete.internals import (
-    BoxCox,
     ConvertFinancial,
     DummyEncoder,
     FancyImputer,
@@ -83,7 +82,14 @@ class Scaler(SmartTransformer):
         best_dist = best_dist if p_vals[best_dist] >= self.p_val else None
         if best_dist is None:
             return SerializablePipeline(
-                [("box_cox", BoxCox()), ("robust_scaler", RobustScaler())]
+                [
+                    # Turning off the BoxCox transformer because if the test
+                    # dataset has an even smaller negative min, it will
+                    # break the pipeline.
+                    # TODO add a different transformer if necessary
+                    # ("box_cox", BoxCox()),
+                    ("robust_scaler", RobustScaler())
+                ]
             )
         else:
             return distributions[best_dist]

--- a/foreshadow/tests/test_transformers/test_concrete/test_internals/test_internal.py
+++ b/foreshadow/tests/test_transformers/test_concrete/test_internals/test_internal.py
@@ -61,23 +61,6 @@ def test_dummy_encoder_other():
     assert check.equals(df)
 
 
-def test_box_cox():
-    import numpy as np
-    import pandas as pd
-    import scipy.stats as ss
-
-    from foreshadow.concrete import BoxCox
-
-    np.random.seed(0)
-    data = pd.DataFrame(ss.lognorm.rvs(size=100, s=0.954))
-    bc = BoxCox()
-    bc_data = bc.fit_transform(data)
-    assert ss.shapiro(bc_data)[1] > 0.05
-    assert np.allclose(
-        data.values.ravel(), bc.inverse_transform(bc_data).values.ravel()
-    )
-
-
 @pytest.mark.parametrize("deep", [True, False])
 def test_label_encoder_get_params_keys(deep):
     """Test that the desired keys show up for the LabelEncoder object.

--- a/foreshadow/tests/test_transformers/test_smart/test_smart.py
+++ b/foreshadow/tests/test_transformers/test_smart/test_smart.py
@@ -50,9 +50,7 @@ def test_smart_get_params_default(smart_child, smart_params, deep):
     assert smart_params == params
 
 
-@pytest.mark.parametrize(
-    "initial_transformer", [None, "BoxCox", "StandardScaler"]
-)
+@pytest.mark.parametrize("initial_transformer", [None, "StandardScaler"])
 def test_smart_get_params_deep(smart_child, smart_params, initial_transformer):
     """Test that smart.get_params(deep=True) functions as desired.
 
@@ -78,9 +76,7 @@ def test_smart_get_params_deep(smart_child, smart_params, initial_transformer):
     assert smart.get_params(True) == smart_params
 
 
-@pytest.mark.parametrize(
-    "initial_transformer", [None, "BoxCox", "StandardScaler"]
-)
+@pytest.mark.parametrize("initial_transformer", [None, "StandardScaler"])
 def test_smart_set_params_default(smart_child, initial_transformer):
     """Test setting both transformer and its parameters simultaneously works.
 


### PR DESCRIPTION
### Description
As we found out in the hackerson, the boxcox transformer is buggy right now so we decided to turn it off for now.

Bug: The min of the test data set can be even smaller than the one we found in the training set, causing the negative shifting function in the transformer to fail.
