### PR TITLE
Fixing the issue of FancyImpute throwing exceptions on columns with n…

### DIFF
--- a/foreshadow/concrete/internals/fancyimpute.py
+++ b/foreshadow/concrete/internals/fancyimpute.py
@@ -96,24 +96,18 @@ class FancyImputer(BaseEstimator, TransformerMixin):
         Returns:
             :obj:`pandas.DataFrame`: Output data
 
-        Raises:
-            e: ValueError
-
         """
-        try:
-            return self.imputer.complete(X)
-        except ValueError as e:
+        if X.isnull().values.any():
             """This is a temporary fix since the newer version of
             fancyimpute package has already fixed the issue of throwing
             exception when there's no missing value. However, due to the
-            constraint on the requirements, we hacve to stage with an older
+            constraint on the requirements, we have to stay with an older
             version and use this workaround until we figure out how to
             upgrade all the associated dependencies.
             """
-            if "Input matrix is not missing any values" in str(e):
-                logging.info(
-                    "No missing value found in column {}".format(X.columns[0])
-                )
-                return X
-            else:
-                raise e
+            return self.imputer.complete(X)
+        else:
+            logging.info(
+                "No missing value found in column {}".format(X.columns[0])
+            )
+            return X

--- a/foreshadow/concrete/internals/fancyimpute.py
+++ b/foreshadow/concrete/internals/fancyimpute.py
@@ -1,6 +1,7 @@
 """Fancy imputation."""
 
 from foreshadow.base import BaseEstimator, TransformerMixin
+from foreshadow.logging import logging
 from foreshadow.wrapper import pandas_wrap
 
 
@@ -95,5 +96,24 @@ class FancyImputer(BaseEstimator, TransformerMixin):
         Returns:
             :obj:`pandas.DataFrame`: Output data
 
+        Raises:
+            e: ValueError
+
         """
-        return self.imputer.complete(X)
+        try:
+            return self.imputer.complete(X)
+        except ValueError as e:
+            """This is a temporary fix since the newer version of
+            fancyimpute package has already fixed the issue of throwing
+            exception when there's no missing value. However, due to the
+            constraint on the requirements, we hacve to stage with an older
+            version and use this workaround until we figure out how to
+            upgrade all the associated dependencies.
+            """
+            if "Input matrix is not missing any values" in str(e):
+                logging.info(
+                    "No missing value found in column {}".format(X.columns[0])
+                )
+                return X
+            else:
+                raise e


### PR DESCRIPTION
### Description
Since we are using an old version of FancyImpute, it may fail on columns with no missing data. The latest version only logs a warning message in that situation. However, since we cannot upgrade due to other dependency issues, we have to use a workaround.
