### PR TITLE
Serialziation and deserialization of  TPOT

### DIFF
--- a/foreshadow/foreshadow.py
+++ b/foreshadow/foreshadow.py
@@ -567,3 +567,42 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
         self.X_preparer.cache_manager["config"][
             ConfigKey.PROCESSED_DATA_EXPORT_PATH
         ] = data_path
+
+    def to_pickle(self, path: str) -> NoReturn:
+        """Pickle the foreshadow object with the best pipeline estimator.
+
+        Args:
+            path: the pickle file path
+
+        """
+        import pickle
+
+        if (
+            isinstance(self.estimator.estimator, AutoEstimator)
+            and self.estimator.estimator.estimator.fitted_pipeline_ is not None
+        ):
+            self.estimator = (
+                self.estimator.estimator.estimator.fitted_pipeline_
+            )
+            # updating the estimator above will not update the reference in
+            # the pipeline instance as it still points to the old object.
+            self.pipeline.steps[1] = ("estimator", self.estimator)
+        with open(path, "wb") as fopen:
+            pickle.dump(self, fopen)
+
+    @classmethod
+    def from_pickle(cls, path: str):
+        """Unpickle a foreshadow object.
+
+        Args:
+            path: the pickle file path
+
+        Returns:
+            A foreshadow object.
+
+        """
+        import pickle
+
+        with open(path, "rb") as fopen:
+            foreshadow = pickle.load(fopen)
+        return foreshadow

--- a/foreshadow/foreshadow.py
+++ b/foreshadow/foreshadow.py
@@ -588,11 +588,10 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
             isinstance(self.estimator, AutoEstimator)
             and self.estimator.estimator.fitted_pipeline_ is not None
         ):
-            self.estimator = (
-                self.estimator.estimator.fitted_pipeline_
-            )
+            self.estimator = self.estimator.estimator.fitted_pipeline_
             # updating the estimator above will not update the reference in
             # the pipeline instance as it still points to the old object.
             self.pipeline.steps[1] = ("estimator", self.estimator)
+
         with open(path, "wb") as fopen:
             pickle.dump(self.pipeline, fopen)

--- a/foreshadow/tests/test_foreshadow.py
+++ b/foreshadow/tests/test_foreshadow.py
@@ -1026,9 +1026,16 @@ def test_foreshadow_serialization_tpot():
         cancerX_df, cancery_df, test_size=0.2
     )
 
-    # adult = pd.read_csv("examples/adult_small.csv")
-    # X_df = adult.loc[:, "age":"workclass"]
-    # y_df = adult.loc[:, "class"]
+    # TODO If we use the following dataset, it may fail the test as the
+    #   processed data frame still contains nan. This triggers TPOT auto
+    #   imputation but since it's not part of the fitted pipeline,
+    #   the unpickled foreshadow may fail. We need to make sure one of the
+    #   existing PR handles this by making sure processed data by foreshadow
+    #   contains no nan.
+    #
+    # adult = pd.read_csv("examples/42.csv")
+    # X_df = adult.loc[:, "date":"roots"]
+    # y_df = adult.loc[:, "target"]
     #
     # X_train, X_test, y_train, y_test = train_test_split(
     #     X_df, y_df, test_size=0.2

--- a/foreshadow/tests/test_foreshadow.py
+++ b/foreshadow/tests/test_foreshadow.py
@@ -1009,7 +1009,8 @@ def test_foreshadow_serialization_adults_small_classification():
     assertions.assertAlmostEqual(score1, score2, places=2)
 
 
-def test_foreshadow_serialization_tpot():
+@slow
+def test_foreshadow_pickling_and_unpickling_tpot():
     from foreshadow.foreshadow import Foreshadow
     import pandas as pd
     import numpy as np
@@ -1029,9 +1030,9 @@ def test_foreshadow_serialization_tpot():
     # TODO If we use the following dataset, it may fail the test as the
     #   processed data frame still contains nan. This triggers TPOT auto
     #   imputation but since it's not part of the fitted pipeline,
-    #   the unpickled foreshadow may fail. We need to make sure one of the
-    #   existing PR handles this by making sure processed data by foreshadow
-    #   contains no nan.
+    #   the unpickled foreshadow may fail on prediction. We need to make sure
+    #   one of the existing PR handles this by making sure processed data by
+    #   foreshadow contains no nan.
     #
     # adult = pd.read_csv("examples/42.csv")
     # X_df = adult.loc[:, "date":"roots"]
@@ -1054,20 +1055,11 @@ def test_foreshadow_serialization_tpot():
     )
 
     shadow.fit(X_train, y_train)
+    shadow.to_pickle("shadow_pickled.p")
 
-    # shadow.to_json("foreshadow_tpot.json")
-    shadow.to_pickle("shadow123456.p")
-
-    # Up to this point it works. The only issue is the tpot auto na filler.
-    # If the data has nan and the fitted pipeline cannot handle it, it will
-    # fail.
-
-    shadow2 = Foreshadow.from_pickle("shadow123456.p")
+    shadow2 = Foreshadow.from_pickle("shadow_pickled.p")
     shadow2.fit(X_train, y_train)
 
-    # shadow2 = Foreshadow.from_json("foreshadow_tpot.json")
-    # shadow2.fit(X_train, y_train)
-    #
     score1 = shadow.score(X_test, y_test)
     score2 = shadow2.score(X_test, y_test)
     # given the randomness of the tpot algorithm and the short run

--- a/foreshadow/tests/test_foreshadow.py
+++ b/foreshadow/tests/test_foreshadow.py
@@ -1009,7 +1009,6 @@ def test_foreshadow_serialization_adults_small_classification():
     assertions.assertAlmostEqual(score1, score2, places=2)
 
 
-@slow
 def test_foreshadow_serialization_tpot():
     from foreshadow.foreshadow import Foreshadow
     import pandas as pd
@@ -1027,10 +1026,20 @@ def test_foreshadow_serialization_tpot():
         cancerX_df, cancery_df, test_size=0.2
     )
 
+    # adult = pd.read_csv("examples/adult_small.csv")
+    # X_df = adult.loc[:, "age":"workclass"]
+    # y_df = adult.loc[:, "class"]
+    #
+    # X_train, X_test, y_train, y_test = train_test_split(
+    #     X_df, y_df, test_size=0.2
+    # )
+
     from foreshadow.estimators import AutoEstimator
 
     estimator = AutoEstimator(
-        problem_type=ProblemType.CLASSIFICATION, auto="tpot"
+        problem_type=ProblemType.CLASSIFICATION,
+        auto="tpot",
+        estimator_kwargs={"max_time_mins": 1},
     )
 
     shadow = Foreshadow(
@@ -1039,11 +1048,19 @@ def test_foreshadow_serialization_tpot():
 
     shadow.fit(X_train, y_train)
 
-    shadow.to_json("foreshadow_tpot.json")
+    # shadow.to_json("foreshadow_tpot.json")
+    shadow.to_pickle("shadow123456.p")
 
-    shadow2 = Foreshadow.from_json("foreshadow_tpot.json")
+    # Up to this point it works. The only issue is the tpot auto na filler.
+    # If the data has nan and the fitted pipeline cannot handle it, it will
+    # fail.
+
+    shadow2 = Foreshadow.from_pickle("shadow123456.p")
     shadow2.fit(X_train, y_train)
 
+    # shadow2 = Foreshadow.from_json("foreshadow_tpot.json")
+    # shadow2.fit(X_train, y_train)
+    #
     score1 = shadow.score(X_test, y_test)
     score2 = shadow2.score(X_test, y_test)
     # given the randomness of the tpot algorithm and the short run


### PR DESCRIPTION
### Description
Given the fact that TPOT cannot pickle itself, we have to adopt the suggested alternative of pickling the `fitted_pipeline_` attribute as mentioned https://github.com/EpistasisLab/tpot/issues/520. In another post, the author shared the same problem and had to use the suggested solution:

> The workaround is to fit TPOTClassifier in standalone mode, and create a PMMLPipeline object off the TPOTClassifier.fitted_pipeline_ attribute using the sklearn2pmml.make_pmml_pipeline(Pipeline: pipeline) utility function...The lesson is that the PMML representation is only concerned with the final state – the deployable model. The PMML representation is not concerned with the specifics of the AutoML tool/algorithm, the initial state, or any of the intermediate states of the search process.

Note that if our processed data frame contains NaN, TPOT will auto-impute the missing values. However, the imputation is not part of the fitted_pipeline_ and not something we can extract from TPOT's instance attribute. Therefore, the unpickled instance may fail if the test dataset contains missing value. It relies on Foreshadow to produce a dataframe without missing values, which is addressed by PR https://github.com/georgianpartners/foreshadow/pull/183. 