### PR TITLE
Fix missing transform method in the cleaner mapper.

### DIFF
--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -1,4 +1,6 @@
 """Cleaner module for handling the cleaning and shaping of data."""
+from typing import NoReturn
+
 import pandas as pd
 
 from foreshadow.logging import logging
@@ -51,13 +53,39 @@ class CleanerMapper(PreparerStep):
         Returns:
             A transformed dataframe.
 
+        """
+        Xt = super().fit_transform(X, *args, **kwargs)
+        self._check_empty_dataframe(Xt)
+        return Xt.dropna(axis=1, how="all")
+
+    def transform(self, X, *args, **kwargs):
+        """Clean the dataframe.
+
+        Args:
+            X: the data frame.
+            *args: positional args.
+            **kwargs: key word args.
+
+        Returns:
+            A transformed dataframe.
+
+        """
+        Xt = super().transform(X, *args, **kwargs)
+        self._check_empty_dataframe(Xt)
+        return Xt.dropna(axis=1, how="all")
+
+    def _check_empty_dataframe(self, X) -> NoReturn:
+        """Check if all columns are empty in the dataframe.
+
+        Args:
+            X: the dataframe
+
         Raises:
             ValueError: all columns are dropped.
 
         """
-        Xt = super().fit_transform(X, *args, **kwargs)
-        columns = pd.Series(Xt.columns)
-        empty_columns = columns[Xt.isnull().all(axis=0).values]
+        columns = pd.Series(X.columns)
+        empty_columns = columns[X.isnull().all(axis=0).values]
 
         if len(empty_columns) == len(columns):
             error_message = (
@@ -71,5 +99,3 @@ class CleanerMapper(PreparerStep):
                 "Dropping columns due to missing values over 90%: "
                 "".format(",".join(empty_columns.tolist()))
             )
-
-        return Xt.dropna(axis=1, how="all")

--- a/foreshadow/tests/test_foreshadow.py
+++ b/foreshadow/tests/test_foreshadow.py
@@ -994,8 +994,6 @@ def test_foreshadow_pickling_and_unpickling_non_tpot(tmpdir):
     with open(pickled_file_location, "rb") as fopen:
         pipeline = pickle.load(fopen)
 
-    pipeline.fit(X_train, y_train)
-
     score1 = shadow.score(X_test, y_test)
     score2 = pipeline.score(X_test, y_test)
 
@@ -1047,8 +1045,6 @@ def test_foreshadow_pickling_and_unpickling_tpot(tmpdir):
     with open(pickled_file_location, "rb") as fopen:
         pipeline = pickle.load(fopen)
 
-    pipeline.fit(X_train, y_train)
-
     score1 = shadow.score(X_test, y_test)
     score2 = pipeline.score(X_test, y_test)
 
@@ -1062,7 +1058,7 @@ def test_foreshadow_pickling_and_unpickling_tpot(tmpdir):
 
     # Changing the decimal point to 1 due to failure on azure pipeline but
     # cannot be reproduced locally.
-    assertions.assertAlmostEqual(score1, score2, places=1)
+    assertions.assertAlmostEqual(score1, score2, places=2)
 
 
 def test_foreshadow_configure_sampling():
@@ -1185,3 +1181,67 @@ def test_foreshadow_abort_on_empty_data_frame_after_cleaning(
         "missing values. Aborting foreshadow."
     )
     assert error_msg in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "filename,problem_type,X_start, X_end, target",
+    [
+        (
+            "23380.csv",
+            ProblemType.CLASSIFICATION,
+            "TREE",
+            "INTERNODE_29",
+            "target",
+        )
+    ],
+)
+def test_foreshadow_integration_data_cleaner_can_drop(
+    filename, problem_type, X_start, X_end, target, tmpdir
+):
+    from foreshadow.foreshadow import Foreshadow
+    import pandas as pd
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+
+    np.random.seed(1337)
+
+    local_file_folder = "examples"
+    data = pd.read_csv("/".join([local_file_folder, filename]))
+    X_df = data.loc[:, X_start:X_end]
+    y_df = data.loc[:, target]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X_df, y_df, test_size=0.2
+    )
+
+    from foreshadow.estimators import AutoEstimator
+
+    estimator = AutoEstimator(
+        problem_type=problem_type,
+        auto="tpot",
+        estimator_kwargs={"max_time_mins": 1},
+    )
+
+    shadow = Foreshadow(estimator=estimator, problem_type=problem_type)
+
+    pickled_fitted_pipeline_location = tmpdir.join("fitted_pipeline.p")
+    shadow.fit(X_train, y_train)
+    shadow.pickle_fitted_pipeline(pickled_fitted_pipeline_location)
+
+    import pickle
+
+    with open(pickled_fitted_pipeline_location, "rb") as fopen:
+        pipeline = pickle.load(fopen)
+
+    score1 = shadow.score(X_test, y_test)
+    score2 = pipeline.score(X_test, y_test)
+
+    import unittest
+
+    assertions = unittest.TestCase("__init__")
+    # given the randomness of the tpot algorithm and the short run
+    # time we configured, there is no guarantee the performance can
+    # converge. The test here aims to evaluate if both cases have
+    # produced a reasonable score and the difference is small.
+    # assert score1 > 0.76 and score2 > 0.76
+    assertions.assertAlmostEqual(score1, score2, places=2)


### PR DESCRIPTION

### Description
Fix a missing transform method override in the cleaner mapper. Since the drop action is done by the mapper, not the smart transformer, we have to do the same in the mapper's `transform` method too. This allows empty columns to be dropped during the test/predict/score phase. Otherwise it will not work properly.
