### PR TITLE
Cleaner save empty columns

### DIFF
--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -19,6 +19,7 @@ class CleanerMapper(PreparerStep):
             **kwargs: kwargs to PreparerStep constructor.
 
         """
+        self.empty_columns = None
         super().__init__(**kwargs)
 
     def get_mapping(self, X):
@@ -55,8 +56,8 @@ class CleanerMapper(PreparerStep):
 
         """
         Xt = super().fit_transform(X, *args, **kwargs)
-        self._check_empty_dataframe(Xt)
-        return Xt.dropna(axis=1, how="all")
+        self.empty_columns = self._check_empty_dataframe(Xt)
+        return Xt.drop(columns=self.empty_columns)
 
     def transform(self, X, *args, **kwargs):
         """Clean the dataframe.
@@ -71,14 +72,18 @@ class CleanerMapper(PreparerStep):
 
         """
         Xt = super().transform(X, *args, **kwargs)
-        self._check_empty_dataframe(Xt)
-        return Xt.dropna(axis=1, how="all")
+        # if self.empty_columns is None:
+        #     self.empty_columns = self._check_empty_dataframe(Xt)
+        return Xt.drop(columns=self.empty_columns)
 
     def _check_empty_dataframe(self, X) -> NoReturn:
         """Check if all columns are empty in the dataframe.
 
         Args:
             X: the dataframe
+
+        Returns:
+            the empty columns.
 
         Raises:
             ValueError: all columns are dropped.
@@ -99,3 +104,5 @@ class CleanerMapper(PreparerStep):
                 "Dropping columns due to missing values over 90%: "
                 "".format(",".join(empty_columns.tolist()))
             )
+
+        return empty_columns

--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -32,7 +32,7 @@ def _check_empty_columns(X) -> NoReturn:
         )
         logging.error(error_message)
         raise ValueError(error_message)
-    else:
+    elif len(empty_columns) > 0:
         logging.info(
             "Dropping columns due to missing values over 90%: {}"
             "".format(",".join(empty_columns.tolist()))

--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -103,7 +103,7 @@ class CleanerMapper(PreparerStep):
             A transformed dataframe.
 
         Raises:
-            ValueError: new empty columns detected.
+            ValueError: Cleaner has not been fitted.
 
         """
         if not self.has_fitted():

--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -9,6 +9,50 @@ from foreshadow.smart import Cleaner, Flatten
 from .preparerstep import PreparerStep
 
 
+def _check_empty_columns(X) -> NoReturn:
+    """Check if all columns are empty in the dataframe.
+
+    Args:
+        X: the dataframe
+
+    Returns:
+        the empty columns.
+
+    Raises:
+        ValueError: all columns are dropped.
+
+    """
+    columns = pd.Series(X.columns)
+    empty_columns = columns[X.isnull().all(axis=0).values]
+
+    if len(empty_columns) == len(columns):
+        error_message = (
+            "All columns are dropped since they all have "
+            "over 90% of missing values. Aborting foreshadow."
+        )
+        logging.error(error_message)
+        raise ValueError(error_message)
+    else:
+        logging.info(
+            "Dropping columns due to missing values over 90%: {}"
+            "".format(",".join(empty_columns.tolist()))
+        )
+
+    return empty_columns.tolist()
+
+
+def _abort_if_has_new_empty_columns(current_columns, empty_columns):
+    new_empty_columns = []
+    for column in empty_columns:
+        if column in current_columns:
+            new_empty_columns.append(column)
+    if len(new_empty_columns) > 0:
+        raise ValueError(
+            "Found new empty columns not present in the training "
+            "data. Downstream steps will fail: {}".format(new_empty_columns)
+        )
+
+
 class CleanerMapper(PreparerStep):
     """Determine and perform best data cleaning step."""
 
@@ -56,7 +100,7 @@ class CleanerMapper(PreparerStep):
 
         """
         Xt = super().fit_transform(X, *args, **kwargs)
-        self.empty_columns = self._check_empty_dataframe(Xt)
+        self.empty_columns = _check_empty_columns(Xt)
         return Xt.drop(columns=self.empty_columns)
 
     def transform(self, X, *args, **kwargs):
@@ -70,39 +114,22 @@ class CleanerMapper(PreparerStep):
         Returns:
             A transformed dataframe.
 
-        """
-        Xt = super().transform(X, *args, **kwargs)
-        # if self.empty_columns is None:
-        #     self.empty_columns = self._check_empty_dataframe(Xt)
-        return Xt.drop(columns=self.empty_columns)
-
-    def _check_empty_dataframe(self, X) -> NoReturn:
-        """Check if all columns are empty in the dataframe.
-
-        Args:
-            X: the dataframe
-
-        Returns:
-            the empty columns.
-
         Raises:
-            ValueError: all columns are dropped.
+            ValueError: new empty columns detected.
 
         """
-        columns = pd.Series(X.columns)
-        empty_columns = columns[X.isnull().all(axis=0).values]
+        if not self.empty_columns:
+            raise ValueError("Cleaner has not been fitted yet.")
 
-        if len(empty_columns) == len(columns):
-            error_message = (
-                "All columns are dropped since they all have "
-                "over 90% of missing values. Aborting foreshadow."
-            )
-            logging.error(error_message)
-            raise ValueError(error_message)
-        else:
-            logging.info(
-                "Dropping columns due to missing values over 90%: "
-                "".format(",".join(empty_columns.tolist()))
-            )
+        Xt = super().transform(X, *args, **kwargs)
+        empty_columns_from_transformed_dataset = _check_empty_columns(Xt)
 
-        return empty_columns
+        Xt_after_dropping_columns_identified_during_training = Xt.drop(
+            columns=self.empty_columns
+        )
+
+        _abort_if_has_new_empty_columns(
+            list(Xt_after_dropping_columns_identified_during_training.columns),
+            empty_columns_from_transformed_dataset,
+        )
+        return Xt_after_dropping_columns_identified_during_training

--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -118,7 +118,7 @@ class CleanerMapper(PreparerStep):
             ValueError: new empty columns detected.
 
         """
-        if not self.empty_columns:
+        if self.empty_columns is None:
             raise ValueError("Cleaner has not been fitted yet.")
 
         Xt = super().transform(X, *args, **kwargs)

--- a/foreshadow/steps/preparerstep.py
+++ b/foreshadow/steps/preparerstep.py
@@ -216,6 +216,15 @@ class PreparerStep(
             self.cache_manager = CacheManager()
         super().__init__(**kwargs)
 
+    def has_fitted(self):
+        """Check if the prepare step has been fitted.
+
+        Returns:
+            Whether the step has been fitted.
+
+        """
+        return self._parallel_process is not None
+
     def configure_cache_manager(self, cache_manager):
         """Recursively configure cache_manager attribute.
 

--- a/foreshadow/tests/test_foreshadow.py
+++ b/foreshadow/tests/test_foreshadow.py
@@ -1262,7 +1262,15 @@ def test_foreshadow_integration_data_cleaner_can_drop(
 
 @pytest.mark.parametrize(
     "filename,problem_type,X_start, X_end, target",
-    [("adult_small.csv", ProblemType.REGRESSION, "age", "workclass", "class")],
+    [
+        (
+            "adult_small.csv",
+            ProblemType.CLASSIFICATION,
+            "age",
+            "workclass",
+            "class",
+        )
+    ],
 )
 def test_foreshadow_integration_adult_small_piclking_unpickling(
     filename, problem_type, X_start, X_end, target, tmpdir

--- a/foreshadow/tests/test_foreshadow.py
+++ b/foreshadow/tests/test_foreshadow.py
@@ -1234,6 +1234,9 @@ def test_foreshadow_integration_data_cleaner_can_drop(
     with open(pickled_fitted_pipeline_location, "rb") as fopen:
         pipeline = pickle.load(fopen)
 
+    # If there are new empty columns in the test set, the program should
+    # not fail.
+    X_test[X_start] = np.nan
     score1 = shadow.score(X_test, y_test)
     score2 = pipeline.score(X_test, y_test)
 
@@ -1246,18 +1249,6 @@ def test_foreshadow_integration_data_cleaner_can_drop(
     # produced a reasonable score and the difference is small.
     # assert score1 > 0.76 and score2 > 0.76
     assertions.assertAlmostEqual(score1, score2, places=2)
-
-    # If there are new empty columns in the test set, the program should
-    # abort early and alert the user about the column
-    X_test[X_start] = np.nan
-
-    for model in [shadow, pipeline]:
-        with pytest.raises(ValueError) as e:
-            model.score(X_test, y_test)
-            assert (
-                "Found new empty columns not present in the training "
-                "data" in str(e.value)
-            )
 
 
 @pytest.mark.parametrize(

--- a/foreshadow/tests/test_transformers/test_concrete/test_cleaners/test_data_cleaner.py
+++ b/foreshadow/tests/test_transformers/test_concrete/test_cleaners/test_data_cleaner.py
@@ -1,4 +1,23 @@
 """Test data_cleaner.py"""
+import pytest
+
+
+def test_data_cleaner_transform_before_fit():
+    import pandas as pd
+    from foreshadow.steps import CleanerMapper
+    from foreshadow.cachemanager import CacheManager
+
+    data = pd.DataFrame(
+        {"financials": ["$1.00", "$550.01", "$1234", "$12353.3345"]},
+        columns=["financials"],
+    )
+    cs = CacheManager()
+    dc = CleanerMapper(cache_manager=cs)
+
+    with pytest.raises(ValueError) as e:
+        dc.transform(data)
+
+    assert str(e.value) == "Cleaner has not been fitted yet."
 
 
 def test_data_cleaner_fit():

--- a/foreshadow/tests/test_transformers/test_smart/test_smart.py
+++ b/foreshadow/tests/test_transformers/test_smart/test_smart.py
@@ -193,12 +193,16 @@ def test_smart_encoder_more_than_30_levels():
 
     np.random.seed(0)
     gt_30_random_data = np.random.choice(31, size=500)
+    gt_30_random_data = [item for item in gt_30_random_data.astype(str)]
+    gt_30_random_data[0] = np.nan
     smart_coder = CategoricalEncoder()
     transformer = smart_coder.fit(gt_30_random_data).transformer
     assert isinstance(transformer, SerializablePipeline)
     assert isinstance(transformer.steps[0][1], NaNFiller)
     assert isinstance(transformer.steps[1][1], HashingEncoder)
     assert len(transformer.steps) == 2
+    res = transformer.transform(gt_30_random_data)
+    assert len(res.columns) == 30
 
 
 def test_smart_encoder_more_than_30_levels_that_reduces():


### PR DESCRIPTION
### Description
Currently when cleaner mapper decides to drop some empty columns, it does not remember which columns are dropped. During prediction, it will find all the empty columns from the test set and drop them. 

Normally that's OK if the prediction set has the same empty columns. However, when the test set have empty columns that are not identified during the training process, they will also be dropped and cause error downstream. This change guards against that and fail early to alert the user. 
  
