### PR TITLE
Fix exporter issue when providing override from Categorical to Numerical type

### DIFF
--- a/foreshadow/foreshadow.py
+++ b/foreshadow/foreshadow.py
@@ -478,7 +478,7 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
         # been processed will be visible.
         cache_manager = self.X_preparer.cache_manager
         if self._has_column_in_cache_manager(column_name):
-            return cache_manager["intent"][column_name]
+            return cache_manager[AcceptedKey.INTENT][column_name]
         else:
             logging.info(
                 "No intent exists for column {}. Either the column "
@@ -519,7 +519,7 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
             )
             return False
         cache_manager = self.X_preparer.cache_manager
-        return True if column in cache_manager["intent"] else False
+        return True if column in cache_manager[AcceptedKey.INTENT] else False
 
     def override_intent(self, column_name: str, intent: str) -> NoReturn:
         """Override the intent of a particular column.
@@ -546,10 +546,10 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
         ):
             raise ValueError("Invalid Column {}".format(column_name))
         # Update the intent
-        self.X_preparer.cache_manager["override"][
+        self.X_preparer.cache_manager[AcceptedKey.OVERRIDE][
             "_".join([Override.INTENT, column_name])
         ] = intent
-        self.X_preparer.cache_manager["intent"][column_name] = intent
+        self.X_preparer.cache_manager[AcceptedKey.INTENT][column_name] = intent
 
     def configure_multiprocessing(self, n_job: int = 1) -> NoReturn:
         """Configure the multiprocessing option.
@@ -562,16 +562,22 @@ class Foreshadow(BaseEstimator, ConcreteSerializerMixin):
             ConfigKey.N_JOBS
         ] = n_job
 
-    def set_processed_data_export_path(self, data_path: str) -> NoReturn:
+    def set_processed_data_export_path(
+        self, data_path: str, is_train: bool
+    ) -> NoReturn:
         """Set path to export data before feeding the data to the estimator.
 
         Args:
             data_path: the data path string
+            is_train: whether this is for training data
 
         """
-        self.X_preparer.cache_manager["config"][
-            ConfigKey.PROCESSED_DATA_EXPORT_PATH
-        ] = data_path
+        key = (
+            ConfigKey.PROCESSED_TRAINING_DATA_EXPORT_PATH
+            if is_train
+            else ConfigKey.PROCESSED_TEST_DATA_EXPORT_PATH
+        )
+        self.X_preparer.cache_manager[AcceptedKey.CONFIG][key] = data_path
 
     def pickle_fitted_pipeline(self, path: str) -> NoReturn:
         """Pickle the foreshadow object with the best pipeline estimator.

--- a/foreshadow/steps/data_exporter.py
+++ b/foreshadow/steps/data_exporter.py
@@ -33,7 +33,7 @@ class DataExporterMapper(PreparerStep, AutoIntentMixin):
         )
 
     def fit_transform(self, X, y=None, **fit_params):
-        """Fit then transform this PreparerStep.
+        """Fit then transform a dataframe.
 
         Side-affect: export the dataframe to disk as a csv file.
 
@@ -47,15 +47,57 @@ class DataExporterMapper(PreparerStep, AutoIntentMixin):
 
         """
         Xt = super().fit_transform(X, y, **fit_params)
-        if (
-            ConfigKey.PROCESSED_DATA_EXPORT_PATH
-            not in self.cache_manager["config"]
-        ):
-            data_path = DefaultConfig.PROCESSED_DATA_EXPORT_PATH
-        else:
-            data_path = self.cache_manager["config"][
-                ConfigKey.PROCESSED_DATA_EXPORT_PATH
-            ]
-        Xt.to_csv(data_path, index=False)
-        logging.info("Exported processed data to {}".format(data_path))
+        self._export_data(Xt, is_train=True)
         return Xt
+
+    def transform(self, X, *args, **kwargs):
+        """Transform a dataframe.
+
+        Side-affect: export the dataframe to disk as a csv file.
+
+        Args:
+            X: input DataFrame
+            *args: args to .transform()
+            **kwargs: kwargs to .transform()
+
+        Returns:
+            Result from .transform(), pass through.
+
+        """
+        Xt = super().transform(X, *args, **kwargs)
+        self._export_data(Xt, is_train=False)
+        return Xt
+
+    def _handle_intent_override(self, default_parallel_process):
+        """Handle intent override and see override in the child classes.
+
+        For the data exporter, it should just start from scratch as there is no
+        computation involved anyway.
+
+        Args:
+            default_parallel_process: the default parallel process from scratch
+
+        """
+        self._parallel_process = default_parallel_process
+
+    def _export_data(self, X, is_train=True):
+        data_path = self._determine_export_path(is_train)
+        X.to_csv(data_path, index=False)
+        logging.info("Exported processed data to {}".format(data_path))
+
+    def _determine_export_path(self, is_train=True):
+        key_to_check = (
+            ConfigKey.PROCESSED_TRAINING_DATA_EXPORT_PATH
+            if is_train
+            else ConfigKey.PROCESSED_TEST_DATA_EXPORT_PATH
+        )
+
+        if key_to_check not in self.cache_manager["config"]:
+            data_path = (
+                DefaultConfig.PROCESSED_TRAINING_DATA_EXPORT_PATH
+                if is_train
+                else DefaultConfig.PROCESSED_TEST_DATA_EXPORT_PATH
+            )
+        else:
+            data_path = self.cache_manager["config"][key_to_check]
+        return data_path

--- a/foreshadow/tests/test_steps/test_data_exporter.py
+++ b/foreshadow/tests/test_steps/test_data_exporter.py
@@ -1,29 +1,93 @@
 """Test Data Exporter"""
 
+import pandas as pd
+import pytest
+
 from foreshadow.cachemanager import CacheManager
 from foreshadow.steps import DataExporterMapper
-from foreshadow.utils import AcceptedKey, ConfigKey
+from foreshadow.utils import AcceptedKey, ConfigKey, DefaultConfig
 
 
-def test_data_exporter_fit_transform(tmpdir):
-    export_path = tmpdir.join("data_export.csv")
-    cache_manager = CacheManager()
-    cache_manager[AcceptedKey.CONFIG][
-        ConfigKey.PROCESSED_DATA_EXPORT_PATH
-    ] = export_path
-
-    exporter = DataExporterMapper(cache_manager=cache_manager)
-
-    from sklearn.datasets import load_breast_cancer
-    import pandas as pd
-
-    cancer = load_breast_cancer()
-    cancerX_df = pd.DataFrame(cancer.data, columns=cancer.feature_names)
-
-    processed_df = exporter.fit_transform(X=cancerX_df)
-
+def _assert_common(export_path, processed_df, cancerX_df):
     pd.testing.assert_frame_equal(processed_df, cancerX_df)
 
     with open(export_path, "r") as fopen:
         exported_df = pd.read_csv(fopen)
         pd.testing.assert_frame_equal(processed_df, exported_df)
+
+
+def _prepare_data_common():
+    from sklearn.datasets import load_breast_cancer
+
+    cancer = load_breast_cancer()
+    return pd.DataFrame(cancer.data, columns=cancer.feature_names)
+
+
+def test_data_exporter_fit_transform(tmpdir):
+    export_path = tmpdir.join("data_export_training.csv")
+    cache_manager = CacheManager()
+    cache_manager[AcceptedKey.CONFIG][
+        ConfigKey.PROCESSED_TRAINING_DATA_EXPORT_PATH
+    ] = export_path
+
+    exporter = DataExporterMapper(cache_manager=cache_manager)
+
+    df = _prepare_data_common()
+    processed_df = exporter.fit_transform(X=df)
+    _assert_common(export_path, processed_df, df)
+
+
+def test_data_exporter_transform(tmpdir):
+    export_path = tmpdir.join("data_export_test.csv")
+    cache_manager = CacheManager()
+    cache_manager[AcceptedKey.CONFIG][
+        ConfigKey.PROCESSED_TEST_DATA_EXPORT_PATH
+    ] = export_path
+
+    exporter = DataExporterMapper(cache_manager=cache_manager)
+
+    df = _prepare_data_common()
+    # Need to fit before transform, even though this step doesn't fit
+    # anything. This is to stay consistent with all other transformers.
+    _ = exporter.fit(X=df)
+    processed_df = exporter.transform(X=df)
+    _assert_common(export_path, processed_df, df)
+
+
+@pytest.mark.parametrize("is_train", [True, False])
+def test_determine_export_path_default(is_train):
+    cache_manager = CacheManager()
+    exporter = DataExporterMapper(cache_manager=cache_manager)
+
+    data_path = exporter._determine_export_path(is_train=is_train)
+    expected_data_path = (
+        DefaultConfig.PROCESSED_TRAINING_DATA_EXPORT_PATH
+        if is_train
+        else DefaultConfig.PROCESSED_TEST_DATA_EXPORT_PATH
+    )
+    assert data_path == expected_data_path
+
+
+@pytest.mark.parametrize(
+    "is_train, user_specified_path",
+    [
+        (True, "processed_training_data.csv"),
+        (False, "processed_test_data.csv"),
+    ],
+)
+def test_determine_export_path_user_specified(is_train, user_specified_path):
+    cache_manager = CacheManager()
+    key = (
+        ConfigKey.PROCESSED_TRAINING_DATA_EXPORT_PATH
+        if is_train
+        else ConfigKey.PROCESSED_TEST_DATA_EXPORT_PATH
+    )
+
+    cache_manager[AcceptedKey.CONFIG][key] = user_specified_path
+
+    exporter = DataExporterMapper(cache_manager=cache_manager)
+
+    data_path = exporter._determine_export_path(is_train=is_train)
+    expected_data_path = user_specified_path
+
+    assert data_path == expected_data_path

--- a/foreshadow/utils/constants.py
+++ b/foreshadow/utils/constants.py
@@ -4,7 +4,8 @@
 class DefaultConfig:
     """Constants for default configurations."""
 
-    PROCESSED_DATA_EXPORT_PATH = "processed_data.csv"
+    PROCESSED_TRAINING_DATA_EXPORT_PATH = "processed_training_data.csv"
+    PROCESSED_TEST_DATA_EXPORT_PATH = "processed_test_data.csv"
     ENABLE_SAMPLING = True
     SAMPLING_DATASET_SIZE_THRESHOLD = 10000
     SAMPLING_WITH_REPLACEMENT = False
@@ -36,7 +37,8 @@ class ConfigKey:
     SAMPLING_WITH_REPLACEMENT = "with_replacement"
     SAMPLING_FRACTION = "sampling_fraction"
     N_JOBS = "n_jobs"
-    PROCESSED_DATA_EXPORT_PATH = "processed_data_export_path"
+    PROCESSED_TRAINING_DATA_EXPORT_PATH = "processed_training_data_export_path"
+    PROCESSED_TEST_DATA_EXPORT_PATH = "processed_test_data_export_path"
     CUSTOMIZED_CLEANERS = "customized_cleaners"
 
 


### PR DESCRIPTION

### Description
DataExporter failed during an intent override test (from Categorical to Numerical) if we train the model, provide the override and retrain the model. This was not captured before because we only did test on Numerical to Categorical. 

The root cause is that when we change an intent from Categorical to Numerical, the preprocessor (one step ahead of the exporter) generates fewer columns. Imagining that column A with unique values (1,2,3,4) are one hot encoded as A_1, A_2, A_3, A_4 in the first training process. In the process after the override, these one hot encoded columns are gone. 

Due to this reason, the exporter is unable to handle the change right now because the column mapping in the exporter's parallel process is still expecting A_1, A_2, A_3, and A_4. 

The fix is to reset the parallel process when there is intent override. Since there is no computation in the exporter at all, it is safe to reset and start from scratch without any performance drag.

Some extra things:
- Adding more unit tests. 
- Provide data export for testing/prediction process as well.
