### PR TITLE
JSON flattener only process a column that are 100% valid JSON, single…

### DIFF
--- a/foreshadow/concrete/internals/cleaners/json_flattener.py
+++ b/foreshadow/concrete/internals/cleaners/json_flattener.py
@@ -2,6 +2,8 @@
 import json
 from collections import MutableMapping
 
+import pandas as pd
+
 from .base import BaseCleaner
 
 
@@ -62,3 +64,25 @@ class StandardJsonFlattener(BaseCleaner):
     def __init__(self):
         transformations = [json_flatten]
         super().__init__(transformations)
+
+    def metric_score(self, X: pd.DataFrame) -> float:
+        """Compute the score for this cleaner using confidence_computation.
+
+        confidence_computation is passed through init for each subclass.
+        The confidence determines which cleaner/flattener is picked in an
+        OVR fashion.
+
+        Args:
+            X: input DataFrame.
+
+        Returns:
+            float: confidence value.
+
+        """
+        score = super().metric_score(X)
+        if score < 1:
+            # we want to make sure the whole column is valid JSON. Otherwise
+            # it will fail later steps. The reason we are not fixing the
+            # JSON is because the variety of malformed JSON is unbounded.
+            return 0
+        return score


### PR DESCRIPTION


### Description
JSON flattener should only process columns that are 100% valid JSON. 

One of the issues we noticed is the single quoted fake JSON format. A valid JSON object should use double quote on the key and value field:

```
{
  "firstName": "John",
  "lastName": "Smith",
  "age": 27
}
```
**NOT**
```
{
  'firstName': 'John',
  'lastName': 'Smith',
  'age': 27,
}
The problem we have right now is that when calculating the metric score to determine which flattener to use (well we only have one for now), JSONFlattener may be triggered due to some empty field in the column and thus json.load() does not throw exceptions. Even though the rest of the columns are invalid JSON and throw exceptions, the final score is still greater than 0. The JSONFlattener is eventually chosen since there is no better options, and it fails the downstream.

We should, at least for now,  enforce valid JSON format on the input. 
