### PR TITLE
Upgrade cleanup for PrepareSteps

### DIFF
--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -10,38 +10,6 @@ from foreshadow.utils import AcceptedKey, ConfigKey
 from .preparerstep import PreparerStep
 
 
-# def _check_empty_columns(X) -> NoReturn:
-#     """Check if all columns are empty in the dataframe.
-#
-#     Args:
-#         X: the dataframe
-#
-#     Returns:
-#         the empty columns.
-#
-#     Raises:
-#         ValueError: all columns are dropped.
-#
-#     """
-#     columns = pd.Series(X.columns)
-#     empty_columns = columns[X.isnull().all(axis=0).values]
-#
-#     if len(empty_columns) == len(columns):
-#         error_message = (
-#             "All columns are dropped since they all have "
-#             "over 90% of missing values. Aborting foreshadow."
-#         )
-#         logging.error(error_message)
-#         raise ValueError(error_message)
-#     elif len(empty_columns) > 0:
-#         logging.info(
-#             "Identified columns with over 90% missing values: {}"
-#             "".format(",".join(empty_columns.tolist()))
-#         )
-#
-#     return empty_columns.tolist()
-
-
 class CleanerMapper(PreparerStep):
     """Determine and perform best data cleaning step."""
 
@@ -69,14 +37,39 @@ class CleanerMapper(PreparerStep):
             transformed data handled by Pipeline._fit
 
         """
+        self._prepare_feature_processor(X=X)
+        self.feature_processor.fit(X=X)
+        self._empty_columns = self._check_empty_columns(
+            original_columns=X.columns
+        )
+        return self
+
+    def transform(self, X, *args, **kwargs):
+        """Clean the dataframe.
+
+        Args:
+            X: the data frame.
+            *args: positional args.
+            **kwargs: key word args.
+
+        Returns:
+            A transformed dataframe.
+
+        Raises:
+            ValueError: Cleaner has not been fitted.
+
+        """
+        if self._empty_columns is None:
+            raise ValueError("Cleaner has not been fitted yet.")
+
+        Xt = self.feature_processor.transform(X=X)
+        return Xt.drop(columns=self._empty_columns)
+
+    def _prepare_feature_processor(self, X):
         columns = X.columns
         list_of_tuples = [
             (
-                column,
-                # make_pipeline(
-                #     Flatten(cache_manager=self.cache_manager),
-                #     Cleaner(cache_manager=self.cache_manager),
-                # ),
+                column + "_" + Cleaner.__class__.__name__,
                 Cleaner(cache_manager=self.cache_manager),
                 column,
             )
@@ -86,11 +79,6 @@ class CleanerMapper(PreparerStep):
             list_of_tuples,
             n_jobs=self.cache_manager[AcceptedKey.CONFIG][ConfigKey.N_JOBS],
         )
-        self.feature_processor.fit(X=X)
-        self._empty_columns = self._check_empty_columns(
-            original_columns=columns
-        )
-        return self
 
     def _check_empty_columns(self, original_columns: List) -> List:
         empty_columns = []
@@ -114,44 +102,3 @@ class CleanerMapper(PreparerStep):
             )
 
         return empty_columns
-
-    def fit_transform(self, X, *args, **kwargs):
-        """Fit then transform the cleaner step.
-
-        Args:
-            X: the data frame.
-            *args: positional args.
-            **kwargs: key word args.
-
-        Returns:
-            A transformed dataframe.
-
-        """
-        return self.fit(X, *args, **kwargs).transform(X)
-        # Xt = super().fit_transform(X, *args, **kwargs)
-        # self._empty_columns = _check_empty_columns(Xt)
-        # return Xt.drop(columns=self._empty_columns)
-
-    def transform(self, X, *args, **kwargs):
-        """Clean the dataframe.
-
-        Args:
-            X: the data frame.
-            *args: positional args.
-            **kwargs: key word args.
-
-        Returns:
-            A transformed dataframe.
-
-        Raises:
-            ValueError: Cleaner has not been fitted.
-
-        """
-        if self._empty_columns is None:
-            raise ValueError("Cleaner has not been fitted yet.")
-
-        # Xt = super().transform(X, *args, **kwargs)
-
-        Xt = self.feature_processor.transform(X=X)
-        # Xt = pd.DataFrame(data=Xt, columns=X.columns)
-        return Xt.drop(columns=self._empty_columns)

--- a/foreshadow/steps/cleaner.py
+++ b/foreshadow/steps/cleaner.py
@@ -1,11 +1,9 @@
 """Cleaner module for handling the cleaning and shaping of data."""
 from typing import List
 
-from foreshadow.ColumnTransformerWrapper import ColumnTransformerWrapper
 from foreshadow.concrete import DropCleaner
 from foreshadow.logging import logging
 from foreshadow.smart import Cleaner
-from foreshadow.utils import AcceptedKey, ConfigKey
 
 from .preparerstep import PreparerStep
 
@@ -37,7 +35,8 @@ class CleanerMapper(PreparerStep):
             transformed data handled by Pipeline._fit
 
         """
-        self._prepare_feature_processor(X=X)
+        list_of_tuples = self._construct_column_transformer_tuples(X=X)
+        self._prepare_feature_processor(list_of_tuples=list_of_tuples)
         self.feature_processor.fit(X=X)
         self._empty_columns = self._check_empty_columns(
             original_columns=X.columns
@@ -65,7 +64,7 @@ class CleanerMapper(PreparerStep):
         Xt = self.feature_processor.transform(X=X)
         return Xt.drop(columns=self._empty_columns)
 
-    def _prepare_feature_processor(self, X):
+    def _construct_column_transformer_tuples(self, X):
         columns = X.columns
         list_of_tuples = [
             (
@@ -75,10 +74,7 @@ class CleanerMapper(PreparerStep):
             )
             for column in columns
         ]
-        self.feature_processor = ColumnTransformerWrapper(
-            list_of_tuples,
-            n_jobs=self.cache_manager[AcceptedKey.CONFIG][ConfigKey.N_JOBS],
-        )
+        return list_of_tuples
 
     def _check_empty_columns(self, original_columns: List) -> List:
         empty_columns = []

--- a/foreshadow/steps/data_exporter.py
+++ b/foreshadow/steps/data_exporter.py
@@ -69,7 +69,6 @@ class DataExporterMapper(PreparerStep):
             Result from .transform(), pass through.
 
         """
-        # Xt = super().transform(X, *args, **kwargs)
         self._export_data(X, is_train=is_train)
         return X
 

--- a/foreshadow/steps/feature_summarizer.py
+++ b/foreshadow/steps/feature_summarizer.py
@@ -44,25 +44,11 @@ class FeatureSummarizerMapper(PreparerStep):  # noqa
             A transformed dataframe.
 
         """
-        summary = self.summarize(X)
+        summary = self._summarize(X)
         json.dump(summary, open("X_train_summary.json", "w"), indent=4)
         return X
 
-    def fit_transform(self, X, *args, **kwargs):
-        """Fit then transform the cleaner step.
-
-        Args:
-            X: the data frame.
-            *args: positional args.
-            **kwargs: key word args.
-
-        Returns:
-            A transformed dataframe.
-
-        """
-        return self.fit(X, *args, **kwargs).transform(X)
-
-    def summarize(self, X_df):  # noqa
+    def _summarize(self, X_df):
         summary = {}
         for k in X_df.columns.values.tolist():
             intent = self.cache_manager[AcceptedKey.INTENT, k]

--- a/foreshadow/steps/flattener.py
+++ b/foreshadow/steps/flattener.py
@@ -38,20 +38,6 @@ class FlattenMapper(PreparerStep):
         self.feature_processor.fit(X=X)
         return self
 
-    def transform(self, X, *args, **kwargs):
-        """Flatten the dataframe.
-
-        Args:
-            X: the data frame.
-            *args: positional args.
-            **kwargs: key word args.
-
-        Returns:
-            A transformed dataframe.
-
-        """
-        return super().transform(X=X)
-
     def _construct_column_transformer_tuples(self, X):
         columns = X.columns
         list_of_tuples = [

--- a/foreshadow/steps/mapper.py
+++ b/foreshadow/steps/mapper.py
@@ -39,22 +39,6 @@ class IntentMapper(PreparerStep):
 
         return self
 
-    def transform(self, X, *args, **kwargs):
-        """Transform X using this PreparerStep.
-
-        calls underlying parallel process.
-
-        Args:
-            X: input DataFrame
-            *args: args to .transform()
-            **kwargs: kwargs to .transform()
-
-        Returns:
-            result from .transform()
-
-        """
-        return super().transform(X=X)
-
     def _update_cache_manager_with_intents(self):
         for intent_resolver_tuple in self.feature_processor.transformers_:
             intent_resolver = intent_resolver_tuple[1]

--- a/foreshadow/steps/mapper.py
+++ b/foreshadow/steps/mapper.py
@@ -1,8 +1,7 @@
 """Resolver module that computes the intents for input data."""
 
-from foreshadow.ColumnTransformerWrapper import ColumnTransformerWrapper
 from foreshadow.smart.intent_resolving import IntentResolver
-from foreshadow.utils import AcceptedKey, ConfigKey
+from foreshadow.utils import AcceptedKey
 
 from .preparerstep import PreparerStep
 
@@ -33,21 +32,8 @@ class IntentMapper(PreparerStep):
             transformed data handled by Pipeline._fit
 
         """
-        columns = X.columns
-        list_of_tuples = [
-            (
-                column,
-                IntentResolver(
-                    column=column, cache_manager=self.cache_manager
-                ),
-                column,
-            )
-            for column in columns
-        ]
-        self.feature_processor = ColumnTransformerWrapper(
-            list_of_tuples,
-            n_jobs=self.cache_manager[AcceptedKey.CONFIG][ConfigKey.N_JOBS],
-        )
+        list_of_tuples = self._construct_column_transformer_tuples(X=X)
+        self._prepare_feature_processor(list_of_tuples=list_of_tuples)
         self.feature_processor.fit(X=X)
         self._update_cache_manager_with_intents()
 
@@ -66,28 +52,8 @@ class IntentMapper(PreparerStep):
         Returns:
             result from .transform()
 
-        Raises:
-            ValueError: if not fitted.
-
         """
-        if self.feature_processor is None:
-            raise ValueError("not fitted.")
-        Xt = self.feature_processor.transform(X, *args, **kwargs)
-        return Xt
-
-    def fit_transform(self, X, *args, **kwargs):
-        """Fit then transform the cleaner step.
-
-        Args:
-            X: the data frame.
-            *args: positional args.
-            **kwargs: key word args.
-
-        Returns:
-            A transformed dataframe.
-
-        """
-        return self.fit(X, *args, **kwargs).transform(X)
+        return super().transform(X=X)
 
     def _update_cache_manager_with_intents(self):
         for intent_resolver_tuple in self.feature_processor.transformers_:
@@ -96,3 +62,17 @@ class IntentMapper(PreparerStep):
             self.cache_manager[AcceptedKey.INTENT][
                 column_name
             ] = intent_resolver.column_intent
+
+    def _construct_column_transformer_tuples(self, X):
+        columns = X.columns
+        list_of_tuples = [
+            (
+                column + "_" + IntentMapper.__class__.__name__,
+                IntentResolver(
+                    column=column, cache_manager=self.cache_manager
+                ),
+                column,
+            )
+            for column in columns
+        ]
+        return list_of_tuples


### PR DESCRIPTION


### Description
Further clean up of the foreshadow code, mostly focusing on the `PrepareSteps` as there are code we can extract to the parent class.

I did not extract all possible duplicate code, mostly because of readability concerns. If we do the full extraction for the `.fit` method, it will look exactly like the old foreshadow where we need to jump between multiple files to understand code. 

Let me know what you think.
